### PR TITLE
Fixed Error: Calling 'depends_on :python3' is disabled!

### DIFF
--- a/dldr.rb
+++ b/dldr.rb
@@ -5,7 +5,7 @@ class Dldr < Formula
   version "1.0.1"
   sha256 "8189afca3f1ba83178ae2afe50dc02286dbe43328836f639c30ceb9174f17896"
 
-  depends_on :python3
+  depends_on :python
   depends_on "ffmpeg"
 
   resource "docopt" do


### PR DESCRIPTION
```
brew upgrade
Error: Calling 'depends_on :python3' is disabled!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/simonbs/homebrew-dldr/dldr.rb:8:in `<class:Dldr>'
Please report this to the simonbs/dldr tap!
Or, even better, submit a PR to fix it!
If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/simonbs/homebrew-dldr/issues
```